### PR TITLE
Bump up to 1.16

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ NODE_IP_NW   = "192.168.26."
 POD_NW_CIDR  = "10.244.0.0/16"
 
 DOCKER_VER = "5:18.09.5~3-0~ubuntu-xenial"
-KUBE_VER   = "1.14.3"
+KUBE_VER   = "1.16.0"
 KUBE_TOKEN = "ayngk7.m1555duk5x2i3ctt"
 IMAGE_REPO = "registry.aliyuncs.com/google_containers"
 

--- a/kube-flannel.yml
+++ b/kube-flannel.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: psp.flannel.unprivileged
@@ -105,6 +105,7 @@ metadata:
 data:
   cni-conf.json: |
     {
+      "cniVersion": "0.2.0",
       "name": "cbr0",
       "plugins": [
         {
@@ -130,7 +131,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-amd64
@@ -139,15 +140,29 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      app: flannel
   template:
     metadata:
       labels:
         tier: node
         app: flannel
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -211,7 +226,7 @@ spec:
           configMap:
             name: kube-flannel-cfg
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-arm64
@@ -220,15 +235,29 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      app: flannel
   template:
     metadata:
       labels:
         tier: node
         app: flannel
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - arm64
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: arm64
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -255,6 +284,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --iface=enp0s8
         resources:
           requests:
             cpu: "100m"
@@ -291,7 +321,7 @@ spec:
           configMap:
             name: kube-flannel-cfg
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-arm
@@ -300,15 +330,29 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      app: flannel
   template:
     metadata:
       labels:
         tier: node
         app: flannel
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - arm
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: arm
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -335,6 +379,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --iface=enp0s8
         resources:
           requests:
             cpu: "100m"
@@ -371,7 +416,7 @@ spec:
           configMap:
             name: kube-flannel-cfg
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-ppc64le
@@ -380,15 +425,29 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      app: flannel
   template:
     metadata:
       labels:
         tier: node
         app: flannel
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - ppc64le
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: ppc64le
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -415,6 +474,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --iface=enp0s8
         resources:
           requests:
             cpu: "100m"
@@ -451,7 +511,7 @@ spec:
           configMap:
             name: kube-flannel-cfg
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-s390x
@@ -460,15 +520,29 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      app: flannel
   template:
     metadata:
       labels:
         tier: node
         app: flannel
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - s390x
       hostNetwork: true
-      nodeSelector:
-        beta.kubernetes.io/arch: s390x
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -495,6 +569,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --iface=enp0s8
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
Update flannel yaml as per
https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network
Flannel was binding to enp0s3 which was default vagrant ip 10.0.2.15
Had to add --iface to use enp0s8
```
root@master:/home/vagrant# kubectl get pods  -o wide --all-namespaces
NAMESPACE     NAME                                READY   STATUS    RESTARTS   AGE   IP              NODE     NOMINATED NODE   READINESS GATES
default       nginx-deployment-54f57cf6bf-hh5ql   1/1     Running   0          23m   10.244.1.4      node1    <none>           <none>
default       nginx-deployment-54f57cf6bf-tkptb   1/1     Running   0          23m   10.244.2.5      node2    <none>           <none>
kube-system   coredns-9d85f5447-jhh7n             1/1     Running   0          83m   10.244.0.3      master   <none>           <none>
kube-system   coredns-9d85f5447-lr9w5             1/1     Running   0          83m   10.244.0.2      master   <none>           <none>
kube-system   etcd-master                         1/1     Running   0          83m   192.168.26.10   master   <none>           <none>
kube-system   kube-apiserver-master               1/1     Running   0          83m   192.168.26.10   master   <none>           <none>
kube-system   kube-controller-manager-master      1/1     Running   0          83m   192.168.26.10   master   <none>           <none>
kube-system   kube-flannel-ds-amd64-2qwk4         1/1     Running   0          31m   192.168.26.10   master   <none>           <none>
kube-system   kube-flannel-ds-amd64-9s4xg         1/1     Running   0          31m   192.168.26.22   node2    <none>           <none>
kube-system   kube-flannel-ds-amd64-cgxfq         1/1     Running   0          31m   192.168.26.21   node1    <none>           <none>
kube-system   kube-proxy-5qkg8                    1/1     Running   0          76m   192.168.26.22   node2    <none>           <none>
kube-system   kube-proxy-9t9bz                    1/1     Running   0          79m   192.168.26.21   node1    <none>           <none>
kube-system   kube-proxy-nfsn4                    1/1     Running   0          83m   192.168.26.10   master   <none>           <none>
kube-system   kube-scheduler-master               1/1     Running   0          83m   192.168.26.10   master   <none>           <none>
```
Node to pod
```
root@master:/home/vagrant# ping 10.244.1.4
PING 10.244.1.4 (10.244.1.4) 56(84) bytes of data.
64 bytes from 10.244.1.4: icmp_seq=1 ttl=63 time=1.45 ms
```
Pod to pod
```
root@nginx-deployment-54f57cf6bf-hh5ql:/# ping 10.244.2.5
PING 10.244.2.5 (10.244.2.5): 48 data bytes
56 bytes from 10.244.2.5: icmp_seq=0 ttl=62 time=1.394 ms
```

Pod to outside
```
root@nginx-deployment-54f57cf6bf-hh5ql:/# ping google.com
PING google.com (172.217.164.110): 48 data bytes
56 bytes from 172.217.164.110: icmp_seq=0 ttl=61 time=12.086 ms
```